### PR TITLE
Challenge: convert Python dicitonary to XML

### DIFF
--- a/challenge/README.md
+++ b/challenge/README.md
@@ -9,3 +9,15 @@ Example: there are 5 possible ways of paying $8 with $1, $3, and $5 bills
 ## [Multiples](multiples/): what are the multiples of a given set under a target number?
 
 Example: multiples of 3 and 5, below 10 would be: [3, 5, 6, 9]
+
+## [Convert Python dictionary to XML](dictionary-to-xml):
+
+Use each dicitonary item `key` as opening and closing tags, and sandwich the value in between.
+
+Examples:
+
+1. `{"foo": "bar"}` should return:
+   `"<foo>bar</foo>"`
+
+2. `{"foo": [1, 2, 3]}` should return:
+   `"<foo><item>1</item><item>2</item><item>3</item></foo>"`

--- a/challenge/dictionary-to-xml/README.md
+++ b/challenge/dictionary-to-xml/README.md
@@ -1,0 +1,6 @@
+# Convert a Python dictionary to XML
+
+The key of the dictionary should go in the opening and closing tags, and
+the value should go inside the tag. Note that if the value is actually a
+`list` itself, each list item must go between opening and closing `item`
+tags. Check the test file for a few examples.

--- a/challenge/dictionary-to-xml/dictionary_to_xml.py
+++ b/challenge/dictionary-to-xml/dictionary_to_xml.py
@@ -1,0 +1,20 @@
+# Convert Python dictionary to XML
+#
+# A quick pair programming challenge, solved with help of Victor.
+#
+# Pedram Ashofteh-Ardakani <pedramardakani@pm.me>
+
+
+def parse_nested(items: list)->str:
+    stack=""
+    for item in items:
+        stack+=f"<item>{item}</item>"
+    return stack
+
+
+def convert(data: dict)->str:
+    stack=""
+    for key, value in data.items():
+        parsed_value = parse_nested(value) if type(value)==list else value
+        stack+=f"<{key}>{parsed_value}</{key}>"
+    return stack

--- a/challenge/dictionary-to-xml/test_dictionary_to_xml.py
+++ b/challenge/dictionary-to-xml/test_dictionary_to_xml.py
@@ -1,0 +1,42 @@
+# Convert Python dictionary to XML
+#
+# Originally, this was written by Victor and Serik, I made a few changes -
+# nothing drastic.
+#
+# Pedram Ashofteh-Ardakani <pedramardakani@pm.me>
+
+
+import unittest
+from dictionary_to_xml import convert
+
+
+class TestCases(unittest.TestCase):
+
+    def test_convert_one_item(self):
+        self.assertEqual(
+            convert({"key": "value"}),
+            "<key>value</key>"
+        )
+
+    def test_convert_multiple_items(self):
+        self.assertEqual(
+            convert({
+                "key": "value",
+                "key-1": "value-1"
+            }), "<key>value</key><key-1>value-1</key-1>"
+        )
+
+    def test_convert_one_item_with_nested_list(self):
+        self.assertEqual(
+            convert({"key": [1, 2, 3]}),
+            "<key><item>1</item><item>2</item><item>3</item></key>"
+        )
+
+    def test_convert_multiple_items_with_nested_list(self):
+        self.assertEqual(
+            convert({"key": [1, 2], "key-1": ["a", "b", 30]}),
+            "<key><item>1</item><item>2</item></key><key-1><item>a</item><item>b</item><item>30</item></key-1>"
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The key of the dictionary should go in the opening and closing tags, and the value should go inside the tag. Note that if the value is actually a `list` itself, each list item must go between opening and closing `item` tags. Check the test file for a few examples.